### PR TITLE
Adds slack integration on failure

### DIFF
--- a/smoke-tests-concourse.yml
+++ b/smoke-tests-concourse.yml
@@ -1,5 +1,17 @@
 ---
 
+resource_types:
+- name: slack-notification
+  type: docker-image
+  source:
+    repository: cfcommunity/slack-notification-resource
+
+- name: metadata
+  type: docker-image
+  source:
+    repository: olhtbr/metadata-resource
+    tag: 2.0.1
+
 resources:
 - name: ecr-govwifi-reg
   type: registry-image
@@ -19,6 +31,14 @@ resources:
   type: time
   source:
     interval: 60m
+
+- name: notify
+  type: slack-notification
+  source:
+    url: ((slack-webhook))
+
+- name: metadata
+  type: metadata
 
 jobs:
 - name: push-to-ecr
@@ -52,6 +72,32 @@ jobs:
   plan:
   - get: interval-60m
     trigger: true
+
+  - put: metadata
+
+  - task: get-failure-message
+    config:
+      platform: linux
+      image_resource:
+        type: docker-image
+        source:
+          repository: busybox
+      inputs:
+        - name: metadata
+      outputs:
+        - name: properties
+      run:
+        path: sh
+        args:
+          - -exc
+          - |
+            atc_external_url=$(cat metadata/atc_external_url)
+            build_team_name=$(cat metadata/build_team_name)
+            build_pipeline_name=$(cat metadata/build_pipeline_name)
+            build_job_name=$(cat metadata/build_job_name)
+            build_name=$(cat metadata/build_name)
+            echo "Smoke Test Failure: $atc_external_url/teams/$build_team_name/pipelines/$build_pipeline_name/jobs/$build_job_name/builds/$build_name" > properties/failure_message
+
   - task: build
     privileged: true
     config:
@@ -67,6 +113,8 @@ jobs:
         path: bundle
         args: ["exec", "rspec"]
         dir: ../../../usr/src/app
+      inputs:
+      - name: properties
       params:
         DOCKER: docker
         GW_USER: "((GW_USER))"
@@ -76,3 +124,7 @@ jobs:
         GOOGLE_API_TOKEN_DATA: "((GOOGLE_API_TOKEN_DATA))"
         RADIUS_KEY: "((RADIUS_KEY))"
         RADIUS_IPS: "((RADIUS_IPS))"
+    on_failure:
+      put: notify
+      params:
+        text_file: properties/failure_message


### PR DESCRIPTION
Configures the slack integration on failed tests.

Test failure now visible on slack.