### PR TITLE
Quick fix - returning within `it` block doesn't work.

### DIFF
--- a/spec/system/signup/signup_spec.rb
+++ b/spec/system/signup/signup_spec.rb
@@ -42,16 +42,16 @@ feature "Signup" do
       Time.new(time_now.year, time_now.month, time_now.day, 1, 15, 0),
     )
 
-    return if radius_server_reboot_scheduled
+    if radius_server_reboot_scheduled
+      radius_ips = ENV["RADIUS_IPS"].split(",")
 
-    radius_ips = ENV["RADIUS_IPS"].split(",")
-
-    radius_ips_successful = EapolTest.make_test(ssid: "GovWifi", identity: identity, password: password) do |eapol_test|
-      radius_ips.select do |radius_ip|
-        eapol_test.execute(ENV["RADIUS_KEY"], radius_ip)
+      radius_ips_successful = EapolTest.make_test(ssid: "GovWifi", identity: identity, password: password) do |eapol_test|
+        radius_ips.select do |radius_ip|
+          eapol_test.execute(ENV["RADIUS_KEY"], radius_ip)
+        end
       end
-    end
 
-    expect(radius_ips_successful).to eq radius_ips
+      expect(radius_ips_successful).to eq radius_ips
+    end
   end
 end


### PR DESCRIPTION
Couldn't test this locally so missed that returning isn't valid inside the `it`.