### PR TITLE
Make admin errors very verbose

### DIFF
--- a/spec/system/admin/locations_page_spec.rb
+++ b/spec/system/admin/locations_page_spec.rb
@@ -4,7 +4,7 @@ feature "Locations Page" do
   it "has the expected content" do
     within(".leftnav") { click_link "Locations" }
 
-    expect(page).to have_xpath("//h1[text()='Locations']"), content_error(page)
+    expect(page).to have_xpath "//h1[text()='Locations']"
   end
 
   describe "Locations", order: :defined do
@@ -24,7 +24,7 @@ feature "Locations Page" do
       fill_in "location[postcode]", with: postcode
       click_button "Add location"
 
-      expect(page).to have_content("Added #{location}, #{postcode}"), content_error(page)
+      expect(page).to have_content "Added #{location}, #{postcode}"
     end
 
     it "adds an IP address" do
@@ -33,14 +33,14 @@ feature "Locations Page" do
       fill_in "location[ips_attributes][0][address]", with: "8.8.8.8"
       click_button "Add IP addresses"
 
-      expect(page).to have_content("Added 1 IP address to #{location}, #{postcode}"), content_error(page)
+      expect(page).to have_content("Added 1 IP address to #{location}, #{postcode}")
     end
 
     it "shows the expected information on overview page" do
       visit "/overview"
 
-      expect(find(:xpath, "//h1[@id='locations-count']")["innerText"].to_i).to be(@locations_count + 1), content_error(page)
-      expect(find(:xpath, "//h1[@id='ips-count']")["innerText"].to_i).to be(@ips_count + 1), content_error(page)
+      expect(find(:xpath, "//h1[@id='locations-count']")["innerText"].to_i).to be(@locations_count + 1)
+      expect(find(:xpath, "//h1[@id='ips-count']")["innerText"].to_i).to be(@ips_count + 1)
     end
 
     it "deletes an IP address" do
@@ -50,7 +50,7 @@ feature "Locations Page" do
       find(:xpath, "//*[contains(text(), '#{location}, #{postcode}')]/ancestor::table/descendant::a[text()='Remove']").click
       click_button "Remove"
 
-      expect(page).to have_content("Successfully removed IP address 8.8.8.8"), content_error(page)
+      expect(page).to have_content "Successfully removed IP address 8.8.8.8"
     end
 
     it "deletes a location" do
@@ -59,14 +59,14 @@ feature "Locations Page" do
       find(:xpath, "//*[contains(text(), '#{location}, #{postcode}')]/ancestor::table/descendant::a[text()='Remove this location']").click
       click_button "Yes, remove this location"
 
-      expect(page).to have_content("Successfully removed location #{location}"), content_error(page)
+      expect(page).to have_content "Successfully removed location #{location}"
     end
 
     it "shows the expected information on overview page" do
       visit "/overview"
 
-      expect(find(:xpath, "//h1[@id='locations-count']")["innerText"].to_i).to be(@locations_count), content_error(page)
-      expect(find(:xpath, "//h1[@id='ips-count']")["innerText"].to_i).to be(@ips_count), content_error(page)
+      expect(find(:xpath, "//h1[@id='locations-count']")["innerText"].to_i).to be(@locations_count)
+      expect(find(:xpath, "//h1[@id='ips-count']")["innerText"].to_i).to be(@ips_count)
     end
   end
 end

--- a/spec/system/admin/logs_page_spec.rb
+++ b/spec/system/admin/logs_page_spec.rb
@@ -3,7 +3,7 @@ feature "Logs Page" do
 
   it "has the expected content" do
     within(".leftnav") { click_link "Logs" }
-    expect(page).to have_content("Logs are kept for recent authentication requests made to the GovWifi service."), content_error(page)
+    expect(page).to have_content "Logs are kept for recent authentication requests made to the GovWifi service."
   end
 
   describe "Search" do
@@ -22,7 +22,7 @@ feature "Logs Page" do
       fill_in "logs_search_search_term", with: "qwert"
       click_button "Show logs"
 
-      expect(page).to have_content("The username \"qwert\" is not reaching the GovWifi service"), content_error(page)
+      expect(page).to have_content "The username \"qwert\" is not reaching the GovWifi service"
     end
   end
 end

--- a/spec/system/admin/settings_page_spec.rb
+++ b/spec/system/admin/settings_page_spec.rb
@@ -16,7 +16,7 @@ feature "Settings Page" do
     it "changes the user's password" do
       change_password ENV["GW_PASS"], new_password
 
-      expect(page).to have_content("Your account has been updated successfully."), content_error(page)
+      expect(page).to have_content "Your account has been updated successfully."
     end
 
     it "logs in with the new password" do
@@ -24,7 +24,7 @@ feature "Settings Page" do
       login(new_password)
       visit "/overview"
 
-      expect(page).to have_xpath("//h2[text()='Overview']"), content_error(page)
+      expect(page).to have_xpath "//h2[text()='Overview']"
 
       change_password new_password, ENV["GW_PASS"]
     end
@@ -34,13 +34,13 @@ feature "Settings Page" do
     it "shows three london servers" do
       within(".leftnav") { click_link "Settings" }
 
-      expect(page).to have_css("#london-radius-ips .ip-address", count: 3), content_error(page)
+      expect(page).to have_css("#london-radius-ips .ip-address", count: 3)
     end
 
     it "shows three dublin servers" do
       within(".leftnav") { click_link "Settings" }
 
-      expect(page).to have_css("#dublin-radius-ips .ip-address", count: 3), content_error(page)
+      expect(page).to have_css("#dublin-radius-ips .ip-address", count: 3)
     end
   end
 end

--- a/spec/system/admin/shared_context.rb
+++ b/spec/system/admin/shared_context.rb
@@ -33,8 +33,4 @@ RSpec.shared_context "admin", shared_context: :metadata do
   def logout
     click_link "Sign out"
   end
-
-  def content_error(page)
-    "Expected content missing from body:\n\n#{page.body}"
-  end
 end

--- a/spec/system/admin/shared_context.rb
+++ b/spec/system/admin/shared_context.rb
@@ -11,7 +11,11 @@ RSpec.shared_context "admin", shared_context: :metadata do
     click_button("accept-cookies") if has_button?("accept-cookies")
   end
 
-  after(:each) do
+  after(:each) do |example|
+    if example.exception
+      warn("\e[35m#{page.body}\e[0m")
+    end
+
     # persist the session
     Capybara.current_session.instance_variable_set(:@touched, false)
   end

--- a/spec/system/admin/switch_organisation_spec.rb
+++ b/spec/system/admin/switch_organisation_spec.rb
@@ -4,13 +4,13 @@ feature "Switch Organisation" do
   it "has the expected content" do
     click_link "Switch organisation"
 
-    expect(page).to have_xpath("//h1[text()='Switch organisation']"), content_error(page)
+    expect(page).to have_xpath "//h1[text()='Switch organisation']"
   end
 
   it "switches location" do
     click_link "Switch organisation"
     click_button "Automated Test 2"
 
-    expect(page).to have_xpath("//div[contains(@class, 'organisation-name')]/strong[text()='Automated Test 2']"), content_error(page)
+    expect(page).to have_xpath "//div[contains(@class, 'organisation-name')]/strong[text()='Automated Test 2']"
   end
 end

--- a/spec/system/admin/team_page_spec.rb
+++ b/spec/system/admin/team_page_spec.rb
@@ -3,7 +3,7 @@ feature "Team Page" do
 
   it "has the expected content" do
     within(".leftnav") { click_link "Team members" }
-    expect(page).to have_xpath("//h1[text()='Team members']"), content_error(page)
+    expect(page).to have_xpath "//h1[text()='Team members']"
   end
 
   describe "Managing Team members", order: :defined do
@@ -20,12 +20,12 @@ feature "Team Page" do
       fill_in "user[email]", with: test_email
       click_button "Send invitation email"
 
-      expect(page).to have_content("#{test_email} has been invited to join"), content_error(page)
+      expect(page).to have_content "#{test_email} has been invited to join"
     end
 
     it "shows the expected information on overview page" do
       visit "/overview"
-      expect(find(:xpath, "//h1[@id='team-members-count']")["innerText"].to_i).to be(@team_members_count + 1), content_error(page)
+      expect(find(:xpath, "//h1[@id='team-members-count']")["innerText"].to_i).to be(@team_members_count + 1)
     end
 
     it "removes a team member" do
@@ -35,12 +35,12 @@ feature "Team Page" do
       click_link "Remove user from GovWifi admin"
       click_button "Yes, remove this team member"
 
-      expect(page).to have_content("Team member has been removed"), content_error(page)
+      expect(page).to have_content "Team member has been removed"
     end
 
     it "shows the expected information on overview page" do
       visit "/overview"
-      expect(find(:xpath, "//h1[@id='team-members-count']")["innerText"].to_i).to be(@team_members_count), content_error(page)
+      expect(find(:xpath, "//h1[@id='team-members-count']")["innerText"].to_i).to be(@team_members_count)
     end
   end
 end


### PR DESCRIPTION
Reverts the earlier change, and reimplements.

The previous one only worked if the expectation was what failed. If anything failed prior to that it did not output the error.

Now we're checking in the `after(:each)` block, so it will dump the page on any failure.