### PR TITLE
Refuse the tracking cookies, so smoke test don't pollute GA data

### DIFF
--- a/spec/system/admin/shared_context.rb
+++ b/spec/system/admin/shared_context.rb
@@ -8,7 +8,7 @@ RSpec.shared_context "admin", shared_context: :metadata do
 
     login
 
-    click_button("accept-cookies") if has_button?("accept-cookies")
+    click_button("refuse-cookies") if has_button?("refuse-cookies")
   end
 
   after(:each) do |example|


### PR DESCRIPTION
## What

Refuse the GA tracking cookie

## Why

Smoke test data is polluting the analytics.