### PR TITLE
Make smoke tests run on prod and staging

### DIFF
--- a/smoke-tests-concourse.yml
+++ b/smoke-tests-concourse.yml
@@ -68,7 +68,7 @@ jobs:
     params:
       image: image/image.tar
 
-- name: run-tests
+- name: run-prod-tests
   plan:
   - get: interval-60m
     trigger: true
@@ -124,6 +124,65 @@ jobs:
         GOOGLE_API_TOKEN_DATA: "((GOOGLE_API_TOKEN_DATA))"
         RADIUS_KEY: "((RADIUS_KEY))"
         RADIUS_IPS: "((RADIUS_IPS))"
+    on_failure:
+      put: notify
+      params:
+        text_file: properties/failure_message
+
+- name: run-staging-tests
+  plan:
+  - put: metadata
+
+  - task: get-failure-message
+    config:
+      platform: linux
+      image_resource:
+        type: docker-image
+        source:
+          repository: busybox
+      inputs:
+        - name: metadata
+      outputs:
+        - name: properties
+      run:
+        path: sh
+        args:
+          - -exc
+          - |
+            atc_external_url=$(cat metadata/atc_external_url)
+            build_team_name=$(cat metadata/build_team_name)
+            build_pipeline_name=$(cat metadata/build_pipeline_name)
+            build_job_name=$(cat metadata/build_job_name)
+            build_name=$(cat metadata/build_name)
+            echo "Smoke Test Failure: $atc_external_url/teams/$build_team_name/pipelines/$build_pipeline_name/jobs/$build_job_name/builds/$build_name" > properties/failure_message
+
+  - task: build
+    privileged: true
+    config:
+      platform: linux
+      image_resource:
+        type: registry-image
+        source:
+          aws_access_key_id: "((deploy-access-key-id))"
+          aws_secret_access_key: "((deploy-secret-access-key))"
+          aws_region: "((deploy-region))"
+          repository: "govwifi/smoke-tests"
+      run:
+        path: bundle
+        args: ["exec", "rspec"]
+        dir: ../../../usr/src/app
+      inputs:
+      - name: properties
+      params:
+        DOCKER: docker
+        GW_USER: "((GW_USER))"
+        GW_PASS: "((GW_PASS))"
+        GW_2FA_SECRET: "((GW_2FA_SECRET))"
+        GOOGLE_API_CREDENTIALS: "((GOOGLE_API_CREDENTIALS))"
+        GOOGLE_API_TOKEN_DATA: "((GOOGLE_API_TOKEN_DATA))"
+        RADIUS_KEY: "((RADIUS_KEY))"
+        RADIUS_IPS: "((RADIUS_IPS))"
+        STAGING: 1
     on_failure:
       put: notify
       params:

--- a/smoke-tests-concourse.yml
+++ b/smoke-tests-concourse.yml
@@ -177,11 +177,11 @@ jobs:
         DOCKER: docker
         GW_USER: "((GW_USER))"
         GW_PASS: "((GW_PASS))"
-        GW_2FA_SECRET: "((GW_2FA_SECRET))"
+        GW_2FA_SECRET: "((STAGING_GW_2FA_SECRET))"
         GOOGLE_API_CREDENTIALS: "((GOOGLE_API_CREDENTIALS))"
         GOOGLE_API_TOKEN_DATA: "((GOOGLE_API_TOKEN_DATA))"
-        RADIUS_KEY: "((RADIUS_KEY))"
-        RADIUS_IPS: "((RADIUS_IPS))"
+        RADIUS_KEY: "((STAGING_RADIUS_KEY))"
+        RADIUS_IPS: "((STAGING_RADIUS_IPS))"
         STAGING: 1
     on_failure:
       put: notify

--- a/smoke-tests-concourse.yml
+++ b/smoke-tests-concourse.yml
@@ -175,8 +175,8 @@ jobs:
       - name: properties
       params:
         DOCKER: docker
-        GW_USER: "((GW_USER))"
-        GW_PASS: "((GW_PASS))"
+        GW_USER: "((STAGING_GW_USER))"
+        GW_PASS: "((STAGING_GW_PASS))"
         GW_2FA_SECRET: "((STAGING_GW_2FA_SECRET))"
         GOOGLE_API_CREDENTIALS: "((GOOGLE_API_CREDENTIALS))"
         GOOGLE_API_TOKEN_DATA: "((GOOGLE_API_TOKEN_DATA))"

--- a/spec/system/admin/shared_context.rb
+++ b/spec/system/admin/shared_context.rb
@@ -1,6 +1,9 @@
 RSpec.shared_context "admin", shared_context: :metadata do
   before(:all) do
-    Capybara.app_host = "http://admin.wifi.service.gov.uk"
+    if ENV["STAGING"] 
+      Capybara.app_host = "http://admin.staging.wifi.service.gov.uk"
+    else
+      Capybara.app_host = "http://admin.wifi.service.gov.uk"
 
     unless ENV["GW_USER"] && ENV["GW_PASS"] && ENV["GW_2FA_SECRET"]
       abort "\e[31mMust define GW_USER, GW_PASS, and GW_2FA_SECRET\e[0m"

--- a/spec/system/signup/signup_spec.rb
+++ b/spec/system/signup/signup_spec.rb
@@ -9,8 +9,13 @@ feature "Signup" do
 
     test_email = gmail.account_email.gsub(/@/, "+#{Time.now.to_i}@")
 
+    if ENV["STAGING"] 
+      emailaddress="signup@wifi.staging.service.gov.uk"
+    else
+      emailaddress="signup@wifi.service.gov.uk"
+
     gmail.send_email(
-      "signup@wifi.service.gov.uk",
+      emailaddress,
       test_email,
       "",
       "",

--- a/spec/system/signup/signup_spec.rb
+++ b/spec/system/signup/signup_spec.rb
@@ -10,7 +10,7 @@ feature "Signup" do
     test_email = gmail.account_email.gsub(/@/, "+#{Time.now.to_i}@")
 
     if ENV["STAGING"] 
-      emailaddress="signup@wifi.staging.service.gov.uk"
+      emailaddress="signup@staging.wifi.service.gov.uk"
     else
       emailaddress="signup@wifi.service.gov.uk"
 


### PR DESCRIPTION
**WHAT**

Enable smoke tests to be run on production (every 60mins) AND staging (adhoc click to run)

**WHY**

Currently smoke tests just run on production - with many dependabot updates needed the ability to smoke test staging on demand without need to manually do it after hacking codes etc is a no brainer - doing this in code once is roughly the same time as doing it manually once - 