### PR TITLE
make it so only one instance of each job can run at once

### DIFF
--- a/smoke-tests-concourse.yml
+++ b/smoke-tests-concourse.yml
@@ -42,6 +42,7 @@ resources:
 
 jobs:
 - name: push-to-ecr
+  max_in_flight: 1
   plan:
   - get: git-repo
 
@@ -69,6 +70,7 @@ jobs:
       image: image/image.tar
 
 - name: run-prod-tests
+  max_in_flight: 1
   plan:
   - get: interval-60m
     trigger: true
@@ -130,6 +132,7 @@ jobs:
         text_file: properties/failure_message
 
 - name: run-staging-tests
+  max_in_flight: 1
   plan:
   - put: metadata
 


### PR DESCRIPTION
**WHAT**

Make it so each concourse pipeline can only run once at a time

**WHY**

Or we can get clogged up with lots of semi failed builds running at once
e.g.
![image](https://user-images.githubusercontent.com/77979241/118144508-71f9d780-b404-11eb-848f-aa16eca23d13.png)
