### PR TITLE
New line in received email is `\r\n` not just `\n`

### DIFF
--- a/spec/system/signup/signup_spec.rb
+++ b/spec/system/signup/signup_spec.rb
@@ -36,8 +36,8 @@ feature "Signup" do
       end
     end
 
-    identity = body.scan(/Your username:\n([a-z]{6})/)&.first&.first
-    password = body.scan(/Your password:\n((?:[A-Z][a-z]+){3})/)&.first&.first
+    identity = body.scan(/Your username:[\r\n]+([a-z]{6})/)&.first&.first
+    password = body.scan(/Your password:[\r\n]+((?:[A-Z][a-z]+){3})/)&.first&.first
 
     expect(identity).to be
     expect(password).to be

--- a/spec/system/signup/signup_spec.rb
+++ b/spec/system/signup/signup_spec.rb
@@ -36,8 +36,8 @@ feature "Signup" do
       end
     end
 
-    identity = body.scan(/Your username:[\r\n]+([a-z]{6})/)&.first&.first
-    password = body.scan(/Your password:[\r\n]+((?:[A-Z][a-z]+){3})/)&.first&.first
+    identity = body.scan(/Your username:\r\n([a-z]{6})/)&.first&.first
+    password = body.scan(/Your password:\r\n((?:[A-Z][a-z]+){3})/)&.first&.first
 
     expect(identity).to be
     expect(password).to be


### PR DESCRIPTION
## What

Follow up to previous PR, add `\r\n` when checking for newline

## Why

Because that's how it comes through in the email.