### PR TITLE
Add tag to ECR image

### DIFF
--- a/smoke-tests-concourse.yml
+++ b/smoke-tests-concourse.yml
@@ -20,6 +20,7 @@ resources:
     aws_secret_access_key: "((deploy-secret-access-key))"
     aws_region: "((deploy-region))"
     repository: "govwifi/smoke-tests"
+    tag: latest
 
 - name: git-repo
   type: git


### PR DESCRIPTION
## What

Add `latest` tag to ECR image

## Why

An error started occurring saying tag or version must be specified. It can't just be any tag though, has to be `latest` for it to be picked up by the tests.