### PR TITLE
Update button text to match code change.

### DIFF
--- a/spec/system/admin/shared_context.rb
+++ b/spec/system/admin/shared_context.rb
@@ -34,7 +34,7 @@ RSpec.shared_context "admin", shared_context: :metadata do
 
       totp = ROTP::TOTP.new(ENV["GW_2FA_SECRET"])
       fill_in "code", with: totp.now
-      click_button "Authenticate"
+      click_button "Continue"
     end
   end
 


### PR DESCRIPTION
## What

Change button text when completing 2FA to "Continue".

## Why

Because the change has been made on the admin site.