### PR TITLE
Make Smoke Tests more forgiving when testing RADIUS servers

### DIFF
--- a/lib/eapol_test.rb
+++ b/lib/eapol_test.rb
@@ -18,7 +18,7 @@ class EapolTest
   end
 
   def execute(key, server)
-    result = `eapol_test -r0 -t3 -c #{@file.path} -a #{server} -s #{key}`
+    result = `eapol_test -r2 -t9 -c #{@file.path} -a #{server} -s #{key}`
     last_result = result.split("\n").last
     last_result == "SUCCESS"
   end


### PR DESCRIPTION
### What

Change retries from 0 to 2 and timeout from 3 to 9 seconds 

### Why

90% of the failed Smoke Tests are when one server does not respond and this is UDP (stateless) after all...

Link to Trello card (if applicable): 
