### PR TITLE
Update CI configuration

### DIFF
--- a/smoke-tests-concourse.yml
+++ b/smoke-tests-concourse.yml
@@ -42,6 +42,14 @@ resources:
   type: metadata
 
 jobs:
+- name: self-update
+  serial: true
+  plan:
+    - get: git-repo
+      trigger: true
+    - set_pipeline: smoke-tests
+      file: git-repo/smoke-tests-concourse.yml
+
 - name: push-to-ecr
   max_in_flight: 1
   plan:


### PR DESCRIPTION
### What

* add dependency trigger
* add `self-update` job


### Why

The dependency trigger means a change to the repo will now trigger the job to run. The `self-update` job allows the pipeline to self update.
