### PR TITLE
remove reference to legacy temp environment

### DIFF
--- a/smoke-tests-concourse.yml
+++ b/smoke-tests-concourse.yml
@@ -199,4 +199,4 @@ jobs:
         GOOGLE_API_TOKEN_DATA: "((GOOGLE_API_TOKEN_DATA))"
         RADIUS_KEY: "((SECONDARY_STAGING_RADIUS_KEY))"
         RADIUS_IPS: "((SECONDARY_STAGING_RADIUS_IPS))"
-        SUBDOMAIN: "staging-temp.wifi"
+        SUBDOMAIN: "staging.wifi"


### PR DESCRIPTION
### What
Remove the reference to 'temp' as in staging-temp environment.

### Why
This is now a legacy environment which has been destroyed and replaced by staging proper.

