### PR TITLE
Reinstate smoke tests

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -13,7 +13,7 @@ end
 
 Capybara.configure do |config|
   config.run_server = false
-  config.default_driver = ENV["DOCKER"] ? :selenium_headless : :selenium
+  config.default_driver = :selenium_headless
 end
 
 Dir["./spec/system/*/shared_context.rb"].sort.each { |f| require f }

--- a/spec/system/admin/logs_page_spec.rb
+++ b/spec/system/admin/logs_page_spec.rb
@@ -6,23 +6,16 @@ feature "Logs Page" do
     expect(page).to have_content "Logs are kept for recent authentication requests made to the GovWifi service."
   end
 
-  # describe "Search" do
-  #   it "shows the expected results page" do
-  #     within(".leftnav") { click_link "Logs" }
-  #     choose "Username", visible: false # Styling means the underlying radio is hidden.
-  #
-  #     # This isn't working. I don't know why.
-  #     # It works fine in normal mode, but fails in headless.
-  #     # It's just clicking a button, like any other button.
-  #     # click_button "Go to search"
-  #
-  #     # This is the workaround:
-  #     page.execute_script("$('input[value=\"Go to search\"]').click()")
-  #
-  #     fill_in "logs_search_search_term", with: "qwert"
-  #     click_button "Show logs"
-  #
-  #     expect(page).to have_content "The username \"qwert\" is not reaching the GovWifi service"
-  #   end
-  # end
+  describe "Search" do
+    it "shows the expected results page" do
+      within(".leftnav") { click_link "Logs" }
+      choose "Username", visible: false # Styling means the underlying radio is hidden.
+
+      click_button "Go to search"
+
+      fill_in "logs_search_search_term", with: "qwert"
+      click_button "Show logs"
+      expect(page).to have_content "The username \"qwert\" is not reaching the GovWifi service"
+    end
+  end
 end


### PR DESCRIPTION
### What
Reinstate disabled smoke test

### Why
  Reinstate disabled smoke test

  The Logs Page/search smoke test was disabled because is failed as
  JQuery was removed from the admin portal.

  The test has been fixed by removing an earlier workaround that used
  JQuery and now uses capybara.

  This also means that headless mode can be used, speeding up the
  tests

