### PR TITLE
Use the deploy- secrets for image access for the staging tests

### DIFF
--- a/smoke-tests-concourse.yml
+++ b/smoke-tests-concourse.yml
@@ -180,8 +180,8 @@ jobs:
       image_resource:
         type: registry-image
         source:
-          aws_access_key_id: "((secondary-staging-deploy-access-key-id))"
-          aws_secret_access_key: "((secondary-staging-deploy-secret-access-key))"
+          aws_access_key_id: "((deploy-access-key-id))"
+          aws_secret_access_key: "((deploy-secret-access-key))"
           aws_region: "((deploy-region))"
           repository: "govwifi/smoke-tests"
       run:


### PR DESCRIPTION
### What
Use the deploy- secrets for image access for the staging tests

This means that the ECR repository in the production account is used,
rather than the one in the staging account.

### Why
Because only the production repository was being updated by the
pipeline, the latest image in the staging repository was quite out
date, and eventually this caused the smoke tests to fail (because out
of date code was being used).


Link to Trello card: https://trello.com/b/9jIWLDIa/govwifi-stand-up-q3-2021
