### PR TITLE
Adapt the Smoke Tests for the removal of the /overview page

### DIFF
--- a/spec/system/admin/locations_page_spec.rb
+++ b/spec/system/admin/locations_page_spec.rb
@@ -8,12 +8,6 @@ feature "Locations Page" do
   end
 
   describe "Locations", order: :defined do
-    before(:all) do
-      visit "/overview"
-      @locations_count = find(:xpath, "//p[@id='locations-count']")["innerText"].to_i
-      @ips_count = find(:xpath, "//p[@id='ips-count']")["innerText"].to_i
-    end
-
     let(:location) { "Automated Test Location" }
     let(:postcode) { "N1" }
 
@@ -36,13 +30,6 @@ feature "Locations Page" do
       expect(page).to have_content("Added 1 IP address to #{location}, #{postcode}")
     end
 
-    it "shows the expected information on overview page" do
-      visit "/overview"
-
-      expect(find(:xpath, "//p[@id='locations-count']")["innerText"].to_i).to be(@locations_count + 1)
-      expect(find(:xpath, "//p[@id='ips-count']")["innerText"].to_i).to be(@ips_count + 1)
-    end
-
     it "deletes an IP address" do
       within(".leftnav") { click_link "Locations" }
 
@@ -60,13 +47,6 @@ feature "Locations Page" do
       click_button "Yes, remove this location"
 
       expect(page).to have_content "Successfully removed location #{location}"
-    end
-
-    it "shows the expected information on overview page" do
-      visit "/overview"
-
-      expect(find(:xpath, "//p[@id='locations-count']")["innerText"].to_i).to be(@locations_count)
-      expect(find(:xpath, "//p[@id='ips-count']")["innerText"].to_i).to be(@ips_count)
     end
   end
 end

--- a/spec/system/admin/settings_page_spec.rb
+++ b/spec/system/admin/settings_page_spec.rb
@@ -22,9 +22,8 @@ feature "Settings Page" do
     it "logs in with the new password" do
       logout
       login(new_password)
-      visit "/overview"
 
-      expect(page).to have_xpath "//h1[text()='Overview']"
+      expect(page).to have_xpath "//h1[text()='Locations']"
 
       change_password new_password, ENV["GW_PASS"]
     end

--- a/spec/system/admin/team_page_spec.rb
+++ b/spec/system/admin/team_page_spec.rb
@@ -7,11 +7,6 @@ feature "Team Page" do
   end
 
   describe "Managing Team members", order: :defined do
-    before(:all) do
-      visit "/overview"
-      @team_members_count = find(:xpath, "//p[@id='team-members-count']")["innerText"].to_i
-    end
-
     let(:test_email) { ENV["GW_USER"].sub("@", "+automated-test@") }
 
     it "adds a team member" do
@@ -23,11 +18,6 @@ feature "Team Page" do
       expect(page).to have_content "#{test_email} has been invited to join"
     end
 
-    it "shows the expected information on overview page" do
-      visit "/overview"
-      expect(find(:xpath, "//p[@id='team-members-count']")["innerText"].to_i).to be(@team_members_count + 1)
-    end
-
     it "removes a team member" do
       within(".leftnav") { click_link "Team members" }
 
@@ -36,11 +26,6 @@ feature "Team Page" do
       click_button "Yes, remove this team member"
 
       expect(page).to have_content "Team member has been removed"
-    end
-
-    it "shows the expected information on overview page" do
-      visit "/overview"
-      expect(find(:xpath, "//p[@id='team-members-count']")["innerText"].to_i).to be(@team_members_count)
     end
   end
 end


### PR DESCRIPTION
### What
Adapt the Smoke Tests for the removal of the /overview page

### Why
It was removed in
https://github.com/alphagov/govwifi-admin/pull/1557


Link to Trello card: https://trello.com/c/Za9sk2oK/2032-remove-overview-page