### PR TITLE
Fix the xpath for removing a team member

### DIFF
--- a/spec/system/admin/team_page_spec.rb
+++ b/spec/system/admin/team_page_spec.rb
@@ -21,7 +21,7 @@ feature "Team Page" do
     it "removes a team member" do
       within(".leftnav") { click_link "Team members" }
 
-      find(:xpath, "//*[contains(text(), '#{test_email} (invited)')]/ancestor::dd/descendant::a[contains(text(), 'Edit permissions')]").click
+      find(:xpath, "//*[contains(text(), '#{test_email}')]/ancestor::dd/descendant::a[contains(text(), 'Edit permissions')]").click
       click_link "Remove user from GovWifi admin"
       click_button "Yes, remove this team member"
 


### PR DESCRIPTION
### What
Fix the xpath for removing a team member

### Why
The invited bit appears by the name, rather than the email address, so
remove it from the selector.


Link to Trello card: https://trello.com/c/qGBxPnU0/2087-changes-to-invite-team-member-and-edit-team-member-page-2