### PR TITLE
Add documentation for generating Google API tokens

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,3 +32,8 @@ Then similar to above, except you run rspec directly:
 ```
 GW_USER=email@address.tld GW_PASS=Y0uR_PA55W0rD GW_2FA_SECRET=1234567890ABCDEF bundle exec rspec
 ```
+
+Updating The Google API Token
+-----------------------------
+
+Instructions for updating the [token](https://github.com/alphagov/govwifi-smoke-tests/blob/363d6827e4eb7763003d0d9f4fd4f4288c6fa28a/smoke-tests-concourse.yml#L136) can be found [here](https://docs.google.com/document/d/1uAaho6jRFUyBT4WRFuDN8pfDmHjfYvG6hT_uo4g1pqA/edit#heading=h.2q4zw5lc8jgj)


### PR DESCRIPTION
### What
Add documentation for generating Google API tokens

### Why
The GovWifi smoke tests recently broke when a gmail password was changed. Generating the token was an unnecessarily long and convoluted process. Adding documentation to help with that.

Link to Trello card (if applicable):  https://trello.com/c/TS0mAYay/2282-fix-govwifi-smoketests
