### PR TITLE
Fix intermittent failuers in smoke tests.

### DIFF
--- a/spec/system/signup/signup_spec.rb
+++ b/spec/system/signup/signup_spec.rb
@@ -20,9 +20,10 @@ feature "Signup" do
 
     body = nil
 
+    from_field = ENV['SUBDOMAIN'] == "wifi" ? "govwifi" : "govwifistaging"
     Timeout.timeout(20, nil, "Waited too long for signup email") do
       loop do
-        if (message = gmail.read("is:unread to:#{test_email}"))
+        if (message = gmail.read("from:#{from_field}@notifications.service.gov.uk is:unread to:#{test_email}"))
           body = message&.payload&.parts&.first&.body&.data
           break
         end


### PR DESCRIPTION
Every now and then the smoke tests fail. An Eapol test would be performed for a username and a password and this would fail against all radius servers. 

After investigating, it was found that the username would appear in the sessions table as 'failed'. The username however would be absent in the userdetails table in the users DB. Further investigations uncovered it _was_ present in the user details table in the _staging_ environment.

This leads us to believe emails are sometimes erroneously read from staging instead of production, leading to this error.

This fix filters messages from a particular environment, thereby fixing the problem
