### PR TITLE
Allow more time for an email to arrive.

### DIFF
--- a/spec/system/signup/signup_spec.rb
+++ b/spec/system/signup/signup_spec.rb
@@ -21,7 +21,7 @@ feature "Signup" do
     body = nil
 
     from_field = ENV['SUBDOMAIN'] == "wifi" ? "govwifi" : "govwifistaging"
-    Timeout.timeout(20, nil, "Waited too long for signup email") do
+    Timeout.timeout(50, nil, "Waited too long for signup email") do
       loop do
         if (message = gmail.read("from:#{from_field}@notifications.service.gov.uk is:unread to:#{test_email}"))
           body = message&.payload&.parts&.first&.body&.data
@@ -29,7 +29,7 @@ feature "Signup" do
         end
 
         print "."
-        sleep 1
+        sleep 2
       end
     end
 


### PR DESCRIPTION
The signup test sometimes times out. The email does seem to arrive eventually, so we increase the timeout interval.

https://technologyprogramme.atlassian.net/jira/software/projects/GW/boards/251?selectedIssue=GW-447