### PR TITLE
Update the name of the root key of the credentials hash

### DIFF
--- a/lib/env_token_store.rb
+++ b/lib/env_token_store.rb
@@ -9,8 +9,8 @@ class EnvTokenStore < Google::Auth::TokenStore
     url = URI("https://accounts.google.com/o/oauth2/token")
     response = Net::HTTP.post_form(url, {
       "refresh_token" => token["refresh_token"],
-      "client_id" => creds["installed"]["client_id"],
-      "client_secret" => creds["installed"]["client_secret"],
+      "client_id" => creds["web"]["client_id"],
+      "client_secret" => creds["web"]["client_secret"],
       "grant_type" => "refresh_token",
     })
     result = JSON.parse(response.body)


### PR DESCRIPTION
Update the name of the root key of the credentials hash

We recently renewed the refresh token which forced us to change the OAuth credentials from 'desktop' to 'web' application type. This means the downloaded credentials hash now has 'web' as the key and not 'settings' This change reflects this.

Link to Trello card (if applicable): 
https://technologyprogramme.atlassian.net/jira/software/projects/GW/boards/251?selectedIssue=GW-622