### PR TITLE
Sms journey specs

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,6 +5,7 @@ source "https://rubygems.org"
 group :test do
   gem "capybara"
   gem "google-apis-gmail_v1"
+  gem "notifications-ruby-client"
   gem "rotp"
   gem "rspec"
   gem "rubocop-govuk"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -57,6 +57,8 @@ GEM
     nokogiri (1.14.3)
       mini_portile2 (~> 2.8.0)
       racc (~> 1.4)
+    notifications-ruby-client (5.4.0)
+      jwt (>= 1.5, < 3)
     os (1.1.4)
     parallel (1.23.0)
     parser (3.2.2.1)
@@ -145,6 +147,7 @@ PLATFORMS
 DEPENDENCIES
   capybara
   google-apis-gmail_v1
+  notifications-ruby-client
   rotp
   rspec
   rubocop-govuk

--- a/Makefile
+++ b/Makefile
@@ -23,6 +23,10 @@ test: build
 		-e RADIUS_KEY \
 		-e RADIUS_IPS \
 		-e SUBDOMAIN \
+		-e NOTIFY_SMOKETEST_API_KEY \
+		-e NOTIFY_GO_TEMPLATE_ID \
+		-e GOVWIFI_PHONE_NUMBER \
+		-e SMOKETEST_PHONE_NUMBER \
 		app bundle exec rspec spec/system
 
 stop:
@@ -42,6 +46,10 @@ shell: build
 		-e RADIUS_KEY \
 		-e RADIUS_IPS \
 		-e SUBDOMAIN \
-		app bundle exec sh
+		-e NOTIFY_SMOKETEST_API_KEY \
+		-e NOTIFY_GO_TEMPLATE_ID \
+		-e GOVWIFI_PHONE_NUMBER \
+		-e SMOKETEST_PHONE_NUMBER \
+		 app bundle exec sh
 
 .PHONY: build stop test shell

--- a/lib/notify_sms.rb
+++ b/lib/notify_sms.rb
@@ -1,0 +1,35 @@
+require_relative "../lib/services"
+module NotifySms
+  def send_go_message(phone_number:, template_id:)
+    Services.notify.send_sms(
+      phone_number:,
+      template_id:,
+    )
+  end
+
+  def read_reply_sms(phone_number:, after_id:, timeout: 50)
+    Timeout.timeout(timeout, nil, "Waited too long for signup SMS. Last received SMS is #{after_id}") do
+      normalised_phone_number = normalise(phone_number)
+      while (result = get_first_sms(phone_number: normalised_phone_number))&.id == after_id
+        print "."
+        sleep 1
+      end
+      result.content
+    end
+  end
+
+  def get_first_sms(phone_number:)
+    Services.notify.get_received_texts.collection.find { |message| message.user_number == normalise(phone_number) }
+  end
+
+  def parse_message(message)
+    match = /Username:[\n\r\s]*(?<username>[a-z]{6})[\n\r\s]*Password:[\n\r\s]*(?<password>(?:[A-Z][a-z]+){3})/.match(message)
+    [match[:username], match[:password]]
+  end
+
+private
+
+  def normalise(phone_number)
+    phone_number.delete("+").sub(/^0/, "44")
+  end
+end

--- a/lib/services.rb
+++ b/lib/services.rb
@@ -1,9 +1,14 @@
 require "google/apis/gmail_v1"
 require "googleauth"
+require "notifications/client"
 require_relative "./eapol_test_client"
 require_relative "./env_token_store"
 
 module Services
+  def self.notify
+    @notify ||= Notifications::Client.new(ENV["NOTIFY_SMOKETEST_API_KEY"])
+  end
+
   def self.eapol_test
     EapolTestClient
   end

--- a/spec/lib/notify_sms_spec.rb
+++ b/spec/lib/notify_sms_spec.rb
@@ -1,0 +1,91 @@
+require "notify_sms"
+require "services"
+require "securerandom"
+
+describe NotifySms do
+  include NotifySms
+
+  let(:phone_number) { "447700900000" }
+  let(:notify_client) { instance_double(Notifications::Client) }
+
+  before :each do
+    allow(Services).to receive(:notify).and_return(notify_client)
+  end
+
+  describe "#send_go_message" do
+    it "sends a go message to the phone number" do
+      allow(notify_client).to receive(:send_sms)
+      send_go_message(phone_number:, template_id: "notify_template_id")
+      expect(notify_client).to have_received(:send_sms).with(phone_number:, template_id: "notify_template_id")
+    end
+  end
+
+  describe "#send_go_message" do
+    it "sends a go message to the phone number" do
+      allow(notify_client).to receive(:send_sms)
+      send_go_message(phone_number:, template_id: "notify_template_id")
+      expect(notify_client).to have_received(:send_sms).with(phone_number:, template_id: "notify_template_id")
+    end
+  end
+
+  describe "#read_reply_sms" do
+    let(:new_message) { double(id: "new_id", user_number: phone_number, content: "new_body") }
+    let(:old_message) { double(id: "old_id", user_number: phone_number, content: "old_body") }
+
+    it "returns the first new message even if it is the first one" do
+      allow(notify_client).to receive(:get_received_texts).and_return(double(collection: []),
+                                                                      double(collection: [new_message]))
+      expect(read_reply_sms(phone_number:, after_id: nil, timeout: 2)).to eq "new_body"
+    end
+
+    it "returns the first new message" do
+      allow(notify_client).to receive(:get_received_texts).and_return(double(collection: [old_message]),
+                                                                      double(collection: [new_message, old_message]))
+      expect(read_reply_sms(phone_number:, after_id: "old_id", timeout: 2)).to eq "new_body"
+    end
+
+    describe "normalise phone numbers" do
+      before :each do
+        allow(notify_client).to receive(:get_received_texts).and_return(double(collection: [old_message]),
+                                                                        double(collection: [new_message, old_message]))
+      end
+      it "removes the + from the phone number" do
+        expect(read_reply_sms(phone_number: "+#{phone_number}", after_id: "old_id", timeout: 2)).to eq "new_body"
+      end
+      it "replaces '0' with '44' if the phone number is not international" do
+        expect(read_reply_sms(phone_number: "07700900000", after_id: "old_id", timeout: 2)).to eq "new_body"
+      end
+    end
+
+    it "times out" do
+      allow(notify_client).to receive(:get_received_texts).and_return(double(collection: [old_message]))
+      expect { read_reply_sms(phone_number:, after_id: "old_id", timeout: 2) }.to raise_error(Timeout::Error)
+    end
+  end
+
+  describe "#get_first_sms" do
+    let(:message1) { double(id: "id1", user_number: "07701111111", content: "body1") }
+    let(:message2) { double(id: "id2", user_number: phone_number, content: "body2") }
+
+    it "Ignores messages from other phone numbers" do
+      allow(notify_client).to receive(:get_received_texts).and_return(double(collection: [message1, message2]))
+      expect(get_first_sms(phone_number:).id).to eq("id2")
+    end
+  end
+
+  describe "#parse_message" do
+    it "parses the message" do
+      message = <<~HTML
+        Windows, Apple, and Chromebook users:
+        Username:
+        abcdef
+        Password:
+        DogCatFox
+        Your password is case-sensitive with no spaces between words.
+
+        Go to your wifi settings, select 'GovWifi' and enter your details.
+      HTML
+      expect(parse_message(message)).to eq %w[abcdef DogCatFox]
+    end
+  end
+end

--- a/spec/system/signup/sms_journey_spec.rb
+++ b/spec/system/signup/sms_journey_spec.rb
@@ -1,0 +1,23 @@
+require "notifications/client"
+require_relative "../../../lib/notify_sms"
+require_relative "../../../lib/eapol_test"
+
+feature "SMS Journey" do
+  include NotifySms
+  include EapolTest
+  before :each do
+    remove_user(user: ENV["SMOKETEST_PHONE_NUMBER"])
+  end
+  it "signs up using an SMS journey" do
+    id = get_first_sms(phone_number: ENV["GOVWIFI_PHONE_NUMBER"])&.id
+    send_go_message(phone_number: ENV["GOVWIFI_PHONE_NUMBER"], template_id: ENV["NOTIFY_GO_TEMPLATE_ID"])
+    message = read_reply_sms(phone_number: ENV["GOVWIFI_PHONE_NUMBER"], after_id: id)
+    username, password = parse_message message
+    result = do_eapol_tests(ssid: "GovWifi",
+                            username:,
+                            password:,
+                            radius_ips: ENV["RADIUS_IPS"].split(","),
+                            secret: ENV["RADIUS_KEY"])
+    expect(result).to all(be true)
+  end
+end


### PR DESCRIPTION
## What
Implement the SMS Journey in smoke tests. This uses a new service "GovWifi-Smoketest" in Notify that sends and receives messages to/from GovWifi as though it was a client.

## Why
We are currently not live testing the SMS signup journey. This PR gives us more certainty that our service performs
correctly

Link to JIRA card (if applicable):
https://technologyprogramme.atlassian.net/jira/software/projects/GW/boards/251?selectedIssue=GW-845

