### PR TITLE
Increase the timeout to wait for Notify SMS messages

### DIFF
--- a/lib/notify_sms.rb
+++ b/lib/notify_sms.rb
@@ -7,12 +7,12 @@ module NotifySms
     )
   end
 
-  def read_reply_sms(phone_number:, after_id:, timeout: 50)
+  def read_reply_sms(phone_number:, after_id:, timeout: 120)
     Timeout.timeout(timeout, nil, "Waited too long for signup SMS. Last received SMS is #{after_id}") do
       normalised_phone_number = normalise(phone_number)
       while (result = get_first_sms(phone_number: normalised_phone_number))&.id == after_id
         print "."
-        sleep 1
+        sleep 5
       end
       result.content
     end


### PR DESCRIPTION
### What
Increase the timeout to wait for Notify SMS messages
### Why
The polling loop to check new messages regularly times out and so the time out is increased to make that less likely to happen
