### PR TITLE
Ensure no unread invitation emails are left

### DIFF
--- a/lib/notify_email.rb
+++ b/lib/notify_email.rb
@@ -37,11 +37,23 @@ module NotifyEmail
 
   def fetch_reply(from_address:, to_address:, timeout: 50)
     Timeout.timeout(timeout, nil, "Waited too long for signup email") do
-      while (message = read_email(query: "from:#{from_address} subject:Welcome is:unread to:#{to_address}")).nil?
+      while (message = read_email(query: unread_emails_query(from_address:, to_address:))).nil?
         print "."
         sleep 2
       end
       message
     end
+  end
+
+  def set_all_messages_to_read(from_address:, to_address:)
+    messages = Services.gmail.list_user_messages("me", q: unread_emails_query(from_address:, to_address:)).messages || []
+
+    messages.each do |message|
+      set_read_flag(message:)
+    end
+  end
+
+  def unread_emails_query(from_address:, to_address:)
+    "from:#{from_address} subject:Welcome is:unread to:#{to_address}"
   end
 end

--- a/spec/system/signup/email_journey_spec.rb
+++ b/spec/system/signup/email_journey_spec.rb
@@ -26,11 +26,15 @@ feature "Email Journey" do
     end
   end
   it "signs up successfully" do
+    set_all_messages_to_read(from_address: notify_address, to_address: client_address)
     send_email(from_address: client_address, to_address: signup_address, body: "go")
     message = fetch_reply(from_address: notify_address, to_address: client_address)
     set_read_flag(message:)
 
     username, password = parse_message(message:)
+    expect(username).to_not be_nil
+    expect(password).to_not be_nil
+
     result = do_eapol_tests(ssid: "GovWifi",
                             username:,
                             password:,


### PR DESCRIPTION
### What
This commit adds code that explicitly sets all invitation emails to 'read' before the signup tests start

### Why
If at some point an invitation email is left unread, the smoke test can break, because it may read credentials from an old invitation email
