### PR TITLE
Add sponsor journey

### DIFF
--- a/lib/notify_email.rb
+++ b/lib/notify_email.rb
@@ -29,15 +29,9 @@ module NotifyEmail
     Services.gmail.get_user_message("me", messages[0].id)
   end
 
-  def set_read_flag(message:)
-    Services.gmail.modify_message("me",
-                                  message.id,
-                                  Google::Apis::GmailV1::ModifyMessageRequest.new(remove_label_ids: %w[UNREAD]))
-  end
-
-  def fetch_reply(from_address:, to_address:, timeout: 50)
+  def fetch_reply(query:, timeout: 50)
     Timeout.timeout(timeout, nil, "Waited too long for signup email") do
-      while (message = read_email(query: unread_emails_query(from_address:, to_address:))).nil?
+      while (message = read_email(query:)).nil?
         print "."
         sleep 2
       end
@@ -45,15 +39,13 @@ module NotifyEmail
     end
   end
 
-  def set_all_messages_to_read(from_address:, to_address:)
-    messages = Services.gmail.list_user_messages("me", q: unread_emails_query(from_address:, to_address:)).messages || []
+  def set_all_messages_to_read(query:)
+    messages = Services.gmail.list_user_messages("me", q: query).messages || []
 
     messages.each do |message|
-      set_read_flag(message:)
+      Services.gmail.modify_message("me",
+                                    message.id,
+                                    Google::Apis::GmailV1::ModifyMessageRequest.new(remove_label_ids: %w[UNREAD]))
     end
-  end
-
-  def unread_emails_query(from_address:, to_address:)
-    "from:#{from_address} subject:Welcome is:unread to:#{to_address}"
   end
 end

--- a/lib/notify_email.rb
+++ b/lib/notify_email.rb
@@ -1,6 +1,6 @@
 require_relative "../lib/services"
 module NotifyEmail
-  def parse_message(message:)
+  def parse_email_message(message:)
     data = message.payload.parts.first.body.data
     match = /Your username:[\n\r\s]*(?<username>[a-z]{6})[\n\r\s]*Your password:[\n\r\s]*(?<password>(?:[A-Z][a-z]+){3})/.match(data)
     [match[:username], match[:password]]

--- a/lib/notify_sms.rb
+++ b/lib/notify_sms.rb
@@ -7,12 +7,12 @@ module NotifySms
     )
   end
 
-  def read_reply_sms(phone_number:, after_id:, timeout: 120)
+  def read_reply_sms(phone_number:, after_id:, timeout: 120, interval: 5)
     Timeout.timeout(timeout, nil, "Waited too long for signup SMS. Last received SMS is #{after_id}") do
       normalised_phone_number = normalise(phone_number:)
       while (result = get_first_sms(phone_number: normalised_phone_number))&.id == after_id
         print "."
-        sleep 5
+        sleep interval
       end
       result.content
     end

--- a/lib/notify_sms.rb
+++ b/lib/notify_sms.rb
@@ -22,7 +22,7 @@ module NotifySms
     Services.notify.get_received_texts.collection.find { |message| message.user_number == normalise(phone_number:) }
   end
 
-  def parse_message(message)
+  def parse_sms_message(message:)
     match = /Username:[\n\r\s]*(?<username>[a-z]{6})[\n\r\s]*Password:[\n\r\s]*(?<password>(?:[A-Z][a-z]+){3})/.match(message)
     [match[:username], match[:password]]
   end

--- a/lib/notify_sms.rb
+++ b/lib/notify_sms.rb
@@ -9,7 +9,7 @@ module NotifySms
 
   def read_reply_sms(phone_number:, after_id:, timeout: 120)
     Timeout.timeout(timeout, nil, "Waited too long for signup SMS. Last received SMS is #{after_id}") do
-      normalised_phone_number = normalise(phone_number)
+      normalised_phone_number = normalise(phone_number:)
       while (result = get_first_sms(phone_number: normalised_phone_number))&.id == after_id
         print "."
         sleep 5
@@ -19,7 +19,7 @@ module NotifySms
   end
 
   def get_first_sms(phone_number:)
-    Services.notify.get_received_texts.collection.find { |message| message.user_number == normalise(phone_number) }
+    Services.notify.get_received_texts.collection.find { |message| message.user_number == normalise(phone_number:) }
   end
 
   def parse_message(message)
@@ -27,9 +27,7 @@ module NotifySms
     [match[:username], match[:password]]
   end
 
-private
-
-  def normalise(phone_number)
+  def normalise(phone_number:)
     phone_number.delete("+").sub(/^0/, "44")
   end
 end

--- a/spec/lib/notify_email_spec.rb
+++ b/spec/lib/notify_email_spec.rb
@@ -7,7 +7,7 @@ describe NotifyEmail do
     it "parses the message" do
       raw = File.read(File.expand_path(File.join(File.dirname(__FILE__), "test_email.json")))
       message = Google::Apis::GmailV1::Message.from_json(raw)
-      expect(parse_message(message:)).to eq %w[abcdef FoxCatBear]
+      expect(parse_email_message(message:)).to eq %w[abcdef FoxCatBear]
     end
   end
 end

--- a/spec/lib/notify_sms_spec.rb
+++ b/spec/lib/notify_sms_spec.rb
@@ -85,7 +85,7 @@ describe NotifySms do
 
         Go to your wifi settings, select 'GovWifi' and enter your details.
       HTML
-      expect(parse_message(message)).to eq %w[abcdef DogCatFox]
+      expect(parse_sms_message(message:)).to eq %w[abcdef DogCatFox]
     end
   end
 end

--- a/spec/lib/notify_sms_spec.rb
+++ b/spec/lib/notify_sms_spec.rb
@@ -35,13 +35,13 @@ describe NotifySms do
     it "returns the first new message even if it is the first one" do
       allow(notify_client).to receive(:get_received_texts).and_return(double(collection: []),
                                                                       double(collection: [new_message]))
-      expect(read_reply_sms(phone_number:, after_id: nil, timeout: 2)).to eq "new_body"
+      expect(read_reply_sms(phone_number:, after_id: nil, timeout: 2, interval: 0)).to eq "new_body"
     end
 
     it "returns the first new message" do
       allow(notify_client).to receive(:get_received_texts).and_return(double(collection: [old_message]),
                                                                       double(collection: [new_message, old_message]))
-      expect(read_reply_sms(phone_number:, after_id: "old_id", timeout: 2)).to eq "new_body"
+      expect(read_reply_sms(phone_number:, after_id: "old_id", timeout: 2, interval: 0)).to eq "new_body"
     end
 
     describe "normalise phone numbers" do
@@ -50,16 +50,16 @@ describe NotifySms do
                                                                         double(collection: [new_message, old_message]))
       end
       it "removes the + from the phone number" do
-        expect(read_reply_sms(phone_number: "+#{phone_number}", after_id: "old_id", timeout: 2)).to eq "new_body"
+        expect(read_reply_sms(phone_number: "+#{phone_number}", after_id: "old_id", timeout: 2, interval: 0)).to eq "new_body"
       end
       it "replaces '0' with '44' if the phone number is not international" do
-        expect(read_reply_sms(phone_number: "07700900000", after_id: "old_id", timeout: 2)).to eq "new_body"
+        expect(read_reply_sms(phone_number: "07700900000", after_id: "old_id", timeout: 2, interval: 0)).to eq "new_body"
       end
     end
 
     it "times out" do
       allow(notify_client).to receive(:get_received_texts).and_return(double(collection: [old_message]))
-      expect { read_reply_sms(phone_number:, after_id: "old_id", timeout: 2) }.to raise_error(Timeout::Error)
+      expect { read_reply_sms(phone_number:, after_id: "old_id", timeout: 2, interval: 0) }.to raise_error(Timeout::Error)
     end
   end
 

--- a/spec/system/signup/email_journey_spec.rb
+++ b/spec/system/signup/email_journey_spec.rb
@@ -36,10 +36,10 @@ feature "Email Journey" do
     expect(password).to_not be_nil
 
     radius_outcomes = do_eapol_tests(ssid: "GovWifi",
-                            username:,
-                            password:,
-                            radius_ips: ENV["RADIUS_IPS"].split(","),
-                            secret: ENV["RADIUS_KEY"])
+                                     username:,
+                                     password:,
+                                     radius_ips: ENV["RADIUS_IPS"].split(","),
+                                     secret: ENV["RADIUS_KEY"])
     expect(radius_outcomes).to all(be true), "EAPOL tests failed for #{username}, #{password}"
   end
 end

--- a/spec/system/signup/email_journey_spec.rb
+++ b/spec/system/signup/email_journey_spec.rb
@@ -31,7 +31,7 @@ feature "Email Journey" do
     send_email(from_address:, to_address: signup_address, body: "go")
     message = fetch_reply(query:)
 
-    username, password = parse_message(message:)
+    username, password = parse_email_message(message:)
     expect(username).to_not be_nil
     expect(password).to_not be_nil
 

--- a/spec/system/signup/email_journey_spec.rb
+++ b/spec/system/signup/email_journey_spec.rb
@@ -11,7 +11,6 @@ feature "Email Journey" do
     notify_field = ENV["SUBDOMAIN"] == "wifi" ? "govwifi" : "govwifistaging"
     "#{notify_field}@notifications.service.gov.uk"
   end
-  let(:client_address) { from_address }
 
   before :all do
     remove_user(user: from_address)
@@ -26,10 +25,11 @@ feature "Email Journey" do
     end
   end
   it "signs up successfully" do
-    set_all_messages_to_read(from_address: notify_address, to_address: client_address)
-    send_email(from_address: client_address, to_address: signup_address, body: "go")
-    message = fetch_reply(from_address: notify_address, to_address: client_address)
-    set_read_flag(message:)
+    query = "from:#{notify_address} subject:Welcome is:unread to:#{from_address}"
+
+    set_all_messages_to_read(query:)
+    send_email(from_address:, to_address: signup_address, body: "go")
+    message = fetch_reply(query:)
 
     username, password = parse_message(message:)
     expect(username).to_not be_nil

--- a/spec/system/signup/sms_journey_spec.rb
+++ b/spec/system/signup/sms_journey_spec.rb
@@ -12,7 +12,7 @@ feature "SMS Journey" do
     id = get_first_sms(phone_number: ENV["GOVWIFI_PHONE_NUMBER"])&.id
     send_go_message(phone_number: ENV["GOVWIFI_PHONE_NUMBER"], template_id: ENV["NOTIFY_GO_TEMPLATE_ID"])
     message = read_reply_sms(phone_number: ENV["GOVWIFI_PHONE_NUMBER"], after_id: id)
-    username, password = parse_message message
+    username, password = parse_sms_message(message:)
     result = do_eapol_tests(ssid: "GovWifi",
                             username:,
                             password:,

--- a/spec/system/signup/sponsor_journey_spec.rb
+++ b/spec/system/signup/sponsor_journey_spec.rb
@@ -1,0 +1,96 @@
+require_relative "../../../lib/notify_email"
+require_relative "../../../lib/notify_sms"
+require_relative "../../../lib/eapol_test"
+require_relative "../../../lib/services"
+
+feature "Sponsor Journey" do
+  include NotifyEmail
+  include NotifySms
+  include EapolTest
+
+  before :context do
+    @signup_address = "sponsor@#{ENV['SUBDOMAIN']}.service.gov.uk"
+    @notify_field = ENV["SUBDOMAIN"] == "wifi" ? "govwifi" : "govwifistaging"
+    @notify_address = "#{@notify_field}@notifications.service.gov.uk"
+    @sponsored_email_address = from_address.sub "@", "+sponsored@"
+    @sponsor_email_address = from_address
+    @sponsored_sms_number = ENV["SMOKETEST_PHONE_NUMBER"]
+    @govwifi_sms_number = ENV["GOVWIFI_PHONE_NUMBER"]
+    @body =
+      <<~BODY
+        Could I please sign up the following users to GovWifi?
+              #{@sponsored_email_address}
+        And
+              #{@sponsored_sms_number}
+        Thanks
+      BODY
+
+    remove_user(user: @sponsored_sms_number)
+    remove_user(user: @sponsored_email_address)
+
+    @sponsored_query = "from:#{@notify_address} subject:Welcome is:unread to:#{@sponsored_email_address}"
+    @sponsor_query = "from:#{@notify_address} subject:\"accounts have been created for your guests\" is:unread to:#{@sponsor_email_address}"
+    set_all_messages_to_read(query: @sponsored_query)
+    set_all_messages_to_read(query: @sponsor_query)
+  end
+  describe "Validate preconditions" do
+    it "has removed any smoke test users" do
+      using_session("Admin") do
+        login(username: ENV["GW_SUPER_ADMIN_USER"], password: ENV["GW_SUPER_ADMIN_PASS"], secret: ENV["GW_SUPER_ADMIN_2FA_SECRET"])
+        click_link("User Details")
+        fill_in "Username, email address or phone number", with: @sponsored_email_address
+        click_button "Find user details"
+        expect(page).to have_content("Nothing found")
+        fill_in "Username, email address or phone number", with: @sponsored_sms_number
+        click_button "Find user details"
+        expect(page).to have_content("Nothing found")
+      end
+    end
+    it "has set the 'read' flag on all relevant emails" do
+      expect(read_email(query: @sponsored_query)).to be_nil
+      expect(read_email(query: @sponsor_query)).to be_nil
+    end
+  end
+  describe "Signing up" do
+    before :context do
+      first_sms_message_id = get_first_sms(phone_number: @govwifi_sms_number)&.id
+
+      send_email(from_address:, to_address: @signup_address, body: @body)
+
+      @email_message = fetch_reply(query: @sponsored_query)
+      @sponsor_email_message = fetch_reply(query: @sponsor_query)
+      @sms_message = read_reply_sms(phone_number: @govwifi_sms_number, after_id: first_sms_message_id)
+
+      @sms_username, @sms_password = parse_sms_message(message: @sms_message)
+      @email_username, @email_password = parse_email_message(message: @email_message)
+    end
+    it "sets the sms username and password" do
+      expect(@sms_username).to_not be_nil
+      expect(@sms_password).to_not be_nil
+    end
+    it "sets the email username and password" do
+      expect(@email_username).to_not be_nil
+      expect(@email_password).to_not be_nil
+    end
+    it "includes the all sponsored users in the receipt email" do
+      expect(@sponsor_email_message.payload.parts.first.body.data).to include(@sponsored_email_address)
+      expect(@sponsor_email_message.payload.parts.first.body.data).to include(normalise(phone_number: @sponsored_sms_number))
+    end
+    it "can successfully connect to Radius using the credentials in the email" do
+      email_radius_outcome = do_eapol_tests(ssid: "GovWifi",
+                                            username: @email_username,
+                                            password: @email_password,
+                                            radius_ips: [ENV["RADIUS_IPS"].split(",").first],
+                                            secret: ENV["RADIUS_KEY"]).first
+      expect(email_radius_outcome).to be(true), "EAPOL tests failed for #{@email_username}, #{@email_password}"
+    end
+    it "can successfully connect to Radius using the credentials in the sms" do
+      email_radius_outcome = do_eapol_tests(ssid: "GovWifi",
+                                            username: @sms_username,
+                                            password: @sms_password,
+                                            radius_ips: [ENV["RADIUS_IPS"].split(",").first],
+                                            secret: ENV["RADIUS_KEY"]).first
+      expect(email_radius_outcome).to be(true), "EAPOL tests failed for #{@sms_username}, #{@sms_password}"
+    end
+  end
+end


### PR DESCRIPTION
### What
Add specs for the Sponsor Journey

### Why
We did not smoke test the sponsor journey so far. This test logs in, sends an email and an SMS using the sponsor journey and tests if the credentials can be used to access GovWifi.


Link to Trello card (if applicable): 
https://technologyprogramme.atlassian.net/jira/software/projects/GW/boards/251?selectedIssue=GW-862