### PR TITLE
Increase timeout for receiving SMS messages

### DIFF
--- a/lib/notify_sms.rb
+++ b/lib/notify_sms.rb
@@ -7,7 +7,7 @@ module NotifySms
     )
   end
 
-  def read_reply_sms(phone_number:, after_id:, timeout: 120, interval: 5)
+  def read_reply_sms(phone_number:, after_id:, timeout: 300, interval: 5)
     Timeout.timeout(timeout, nil, "Waited too long for signup SMS. Last received SMS is #{after_id}") do
       normalised_phone_number = normalise(phone_number:)
       while (result = get_first_sms(phone_number: normalised_phone_number))&.id == after_id


### PR DESCRIPTION
### What
Increase timeout for receiving SMS messages

### Why
The smoke tests regularly fail waiting for SMS messages that arrive later than expected.

Link to Trello card (if applicable): 
https://technologyprogramme.atlassian.net/jira/software/projects/GW/boards/251?selectedIssue=GW-925