### PR TITLE
Fix duplicate link error in team page specs

### DIFF
--- a/spec/system/admin/team_page_spec.rb
+++ b/spec/system/admin/team_page_spec.rb
@@ -11,7 +11,7 @@ feature "Team Page" do
 
     it "adds a team member" do
       within(".leftnav") { click_link "Team members" }
-      click_link "Invite a team member"
+      find("a", class: "govuk-button", text: "Invite a team member").click
       fill_in "user[email]", with: test_email
       click_button "Send invitation email"
 


### PR DESCRIPTION
With a recent change requiring 2 administrators, there can now be two links with the label "Invite a team member". This change ensures Capybara finds the correct one.
