### PR TITLE
Increase timeouts to receive emails and SMS

### DIFF
--- a/lib/notify_email.rb
+++ b/lib/notify_email.rb
@@ -29,7 +29,7 @@ module NotifyEmail
     Services.gmail.get_user_message("me", messages[0].id)
   end
 
-  def fetch_reply(query:, timeout: 50)
+  def fetch_reply(query:, timeout: 300)
     Timeout.timeout(timeout, nil, "Waited too long for signup email") do
       while (message = read_email(query:)).nil?
         print "."

--- a/lib/notify_sms.rb
+++ b/lib/notify_sms.rb
@@ -7,7 +7,7 @@ module NotifySms
     )
   end
 
-  def read_reply_sms(phone_number:, after_id:, timeout: 300, interval: 5)
+  def read_reply_sms(phone_number:, after_id:, timeout: 600, interval: 5)
     Timeout.timeout(timeout, nil, "Waited too long for signup SMS. Last received SMS is #{after_id}") do
       normalised_phone_number = normalise(phone_number:)
       while (result = get_first_sms(phone_number: normalised_phone_number))&.id == after_id


### PR DESCRIPTION
The smoke tests fail from time to time because it takes longer than expected to receive an SMS or an email.

This commit increases the email timeouts to 5 minutes and the sms timeouts to 10 minutes
