### PR TITLE
fix [GW-1125] Add Notify_field env var

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,6 +25,7 @@ test: build
 		-e NOTIFY_GO_TEMPLATE_ID \
 		-e GOVWIFI_PHONE_NUMBER \
 		-e SMOKETEST_PHONE_NUMBER \
+		-e NOTIFY_FIELD \
 		app bundle exec rspec spec/system
 
 stop:
@@ -48,6 +49,7 @@ shell: build
 		-e NOTIFY_GO_TEMPLATE_ID \
 		-e GOVWIFI_PHONE_NUMBER \
 		-e SMOKETEST_PHONE_NUMBER \
+		-e NOTIFY_FIELD \
 		 app bundle exec sh
 
 .PHONY: build stop test shell

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ The tests run in a headless browser inside a Docker container. You need to provi
 - `SUBDOMAIN` - the subdomain for your particular environment e.g. `wifi` or `staging.wifi`
 - `GOOGLE_API_CREDENTIALS` - token for the Google API.
 - `GOOGLE_API_TOKEN_DATA` - token for the Google API.
+- `NOTIFY_FIELD` - the notify email prefix, for the given environment, goveifi(development, staging, blank) 
 
 An example of setting the environment variables
 ```
@@ -29,6 +30,7 @@ export GW_SUPER_ADMIN_2FA_SECRET=123
 export SUBDOMAIN=wifi
 export GOOGLE_API_CREDENTIALS='{"access_token....}'
 export GOOGLE_API_TOKEN_DATA='{"web":{....}'
+export NOTIFY_FIELD=govwifidevelopment
 ```
 
 When running the smoke tests, ensure that both the super user and the regular admin user that were defined in the environment variables exist in the admin app.
@@ -43,6 +45,8 @@ You can find the values of the environment variables in AWS secrets manager:
 - `GW_SUPER_ADMIN_2FA_SECRET` - deploy/gw_super_admin_2fa_secret
 - `GOOGLE_API_CREDENTIALS` - deploy/google_api_credentials
 - `GOOGLE_API_TOKEN_DATA` - deploy/google_api_token_data
+
+The NOTIFY_FIELD is set in terraform in the 'smoke_tests' module for each environment.
 
 Then run the tests:
 ```make test```

--- a/spec/system/signup/email_journey_spec.rb
+++ b/spec/system/signup/email_journey_spec.rb
@@ -8,7 +8,7 @@ feature "Email Journey" do
 
   let(:signup_address) { "signup@#{ENV['SUBDOMAIN']}.service.gov.uk" }
   let(:notify_address) do
-    notify_field = ENV["SUBDOMAIN"] == "wifi" ? "govwifi" : "govwifistaging"
+    notify_field = ENV["NOTIFY_FIELD"]
     "#{notify_field}@notifications.service.gov.uk"
   end
 

--- a/spec/system/signup/sponsor_journey_spec.rb
+++ b/spec/system/signup/sponsor_journey_spec.rb
@@ -10,7 +10,7 @@ feature "Sponsor Journey" do
 
   before :context do
     @signup_address = "sponsor@#{ENV['SUBDOMAIN']}.service.gov.uk"
-    @notify_field = ENV["SUBDOMAIN"] == "wifi" ? "govwifi" : "govwifistaging"
+    notify_field = ENV["NOTIFY_FIELD"]
     @notify_address = "#{@notify_field}@notifications.service.gov.uk"
     @sponsored_email_address = from_address.sub "@", "+sponsored@"
     @sponsor_email_address = from_address


### PR DESCRIPTION
### What
Adding a new environment variable to the smoke test to state where the notify emails are coming from.

### Why
So the smoke tests can run on each environment independently 


Link to Trello card (if applicable): 
GW-1125