### PR TITLE
Add test for EAP TLS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,11 @@
 DOCKER_COMPOSE=docker-compose -f docker-compose.yml
 BUNDLE_FLAGS=
+CERTIFICATE_PATH=smoke_test_certificates
+
+ROOT=smoke_test_root_ca
+INTERMEDIATE=smoke_test_intermediate_ca
+CLIENT=smoke_test_client
+VALID_FOR=9000
 
 build:
 	$(DOCKER_COMPOSE) build
@@ -55,5 +61,16 @@ shell: build
 		-e EAP_TLS_CLIENT_CERT \
 		-e EAP_TLS_CLIENT_KEY \
 		 app bundle exec sh
+
+certs:
+	mkdir -p $(CERTIFICATE_PATH)
+	openssl req -x509 -newkey rsa:4096 -keyout $(CERTIFICATE_PATH)/$(ROOT).key -out $(CERTIFICATE_PATH)/$(ROOT).pem -sha256 -days $(VALID_FOR) -nodes -subj '/CN=Smoke Test Root CA'
+
+	openssl req -newkey 4096 -keyout $(CERTIFICATE_PATH)/$(INTERMEDIATE).key -outform pem -keyform pem -out $(CERTIFICATE_PATH)/$(INTERMEDIATE).req -nodes -subj '/CN=Smoke Test Intermediate CA'
+	openssl x509 -req -CA $(CERTIFICATE_PATH)/$(ROOT).pem -CAkey $(CERTIFICATE_PATH)/$(ROOT).key -in $(CERTIFICATE_PATH)/$(INTERMEDIATE).req -out $(CERTIFICATE_PATH)/$(INTERMEDIATE).pem -extensions v3_ca -days $(VALID_FOR) -CAcreateserial -extfile openssl.conf -CAserial $(CERTIFICATE_PATH)/intermediate.srl
+
+	openssl req -newkey 4096 -keyout $(CERTIFICATE_PATH)/$(CLIENT).key -outform pem -keyform pem -out $(CERTIFICATE_PATH)/$(CLIENT).req -nodes -subj '/CN=Client'
+	openssl x509 -req -CA $(CERTIFICATE_PATH)/$(INTERMEDIATE).pem -CAkey $(CERTIFICATE_PATH)/$(INTERMEDIATE).key -in $(CERTIFICATE_PATH)/$(CLIENT).req -out $(CERTIFICATE_PATH)/$(CLIENT).pem -extensions v3_client -days $(VALID_FOR) -CAcreateserial -extfile openssl.conf -CAserial $(CERTIFICATE_PATH)/client.srl
+	rm -f $(CERTIFICATE_PATH)/*.req
 
 .PHONY: build stop test shell

--- a/Makefile
+++ b/Makefile
@@ -26,6 +26,8 @@ test: build
 		-e GOVWIFI_PHONE_NUMBER \
 		-e SMOKETEST_PHONE_NUMBER \
 		-e NOTIFY_FIELD \
+		-e EAP_TLS_CLIENT_CERT \
+		-e EAP_TLS_CLIENT_KEY \
 		app bundle exec rspec spec/system
 
 stop:
@@ -50,6 +52,8 @@ shell: build
 		-e GOVWIFI_PHONE_NUMBER \
 		-e SMOKETEST_PHONE_NUMBER \
 		-e NOTIFY_FIELD \
+		-e EAP_TLS_CLIENT_CERT \
+		-e EAP_TLS_CLIENT_KEY \
 		 app bundle exec sh
 
 .PHONY: build stop test shell

--- a/openssl.conf
+++ b/openssl.conf
@@ -1,0 +1,4 @@
+[v3_ca]
+basicConstraints = CA:TRUE
+[v3_client]
+basicConstraints = CA:FALSE

--- a/spec/system/signup/eap_tls_journey_spec.rb
+++ b/spec/system/signup/eap_tls_journey_spec.rb
@@ -1,0 +1,21 @@
+require_relative "../../../lib/services"
+
+feature "Eap-tls Journey" do
+  it "can connect successfully" do
+    eapol_test = GovwifiEapoltest.new(radius_ips: ENV["RADIUS_IPS"].split(","),
+                                      secret: ENV["RADIUS_KEY"])
+
+    cert_file = Tempfile.new
+    cert_file.write ENV["EAP_TLS_CLIENT_CERT"]
+    cert_file.close
+
+    key_file = Tempfile.new
+    key_file.write ENV["EAP_TLS_CLIENT_KEY"]
+    key_file.close
+
+    output = eapol_test.run_eap_tls(client_cert_path: cert_file.path,
+                                    client_key_path: key_file.path)
+
+    expect(output).to all(have_been_successful), output.join("\n")
+  end
+end


### PR DESCRIPTION
### What
Add test for EAP TLS

### Why
Ensure EAP TLS works by connecting using a known certificate / key

Link to Trello card (if applicable): 
https://technologyprogramme.atlassian.net/jira/software/projects/GW/boards/251?selectedIssue=GW-1117