### PR TITLE
Revert "Bump selenium-webdriver from 4.9.0 to 4.18.1"

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,7 +9,6 @@ GEM
     addressable (2.8.4)
       public_suffix (>= 2.0.2, < 6.0)
     ast (2.4.2)
-    base64 (0.2.0)
     capybara (3.39.0)
       addressable
       matrix
@@ -78,7 +77,7 @@ GEM
       trailblazer-option (>= 0.1.1, < 0.2.0)
       uber (< 0.2.0)
     retriable (3.1.2)
-    rexml (3.2.6)
+    rexml (3.2.5)
     rotp (6.2.2)
     rspec (3.13.0)
       rspec-core (~> 3.13.0)
@@ -125,8 +124,7 @@ GEM
     ruby-progressbar (1.13.0)
     ruby2_keywords (0.0.5)
     rubyzip (2.3.2)
-    selenium-webdriver (4.18.1)
-      base64 (~> 0.2)
+    selenium-webdriver (4.9.0)
       rexml (~> 3.2, >= 3.2.5)
       rubyzip (>= 1.2.2, < 3.0)
       websocket (~> 1.0)
@@ -141,7 +139,7 @@ GEM
     uber (0.1.0)
     unicode-display_width (2.4.2)
     webrick (1.8.1)
-    websocket (1.2.10)
+    websocket (1.2.9)
     xpath (3.2.0)
       nokogiri (~> 1.8)
 


### PR DESCRIPTION
Reverts alphagov/govwifi-smoke-tests#76
Breaking smoke tests.